### PR TITLE
Adds Error handling for registration form if email is already taken

### DIFF
--- a/src/api/user/user.js
+++ b/src/api/user/user.js
@@ -42,7 +42,8 @@ const userSignUp = async data => {
         'Content-Type': 'application/json',
       },
     })
-    return handleFetchErrors(resp)
+    // return handleFetchErrors(resp)
+    return await resp.json()
   } catch (e) {
     throw new Error(e)
   }

--- a/src/components/CreateAccount/index.js
+++ b/src/components/CreateAccount/index.js
@@ -7,7 +7,7 @@ import ValidatedInputField from '../ValidatedInputField'
 import ToolTipModalContainer from '../../containers/ToolTipModalContainer'
 import './styles.scss'
 
-const CreateAccount = ({ handleAccountCreation }) => {
+const CreateAccount = ({ handleAccountCreation, apiErrors }) => {
   const { register, handleSubmit, errors, watch } = useForm()
   const [rulesAccepted, setRulesAccepted] = useState(false)
   const [phoneNumberModalIsOpen, setPhoneNumberModalIsOpen] = useState(false)
@@ -149,7 +149,8 @@ const CreateAccount = ({ handleAccountCreation }) => {
               ariaInvalid={!!errors.email}
               inputClassName="create-account-input-text"
               labelClassName={
-                errors.email
+                errors.email ||
+                (apiErrors && apiErrors.fields && apiErrors.fields.email)
                   ? 'create-account-errors-field'
                   : 'create-account-input-field'
               }
@@ -161,6 +162,9 @@ const CreateAccount = ({ handleAccountCreation }) => {
               {errors.email &&
                 errors.email.type === 'pattern' &&
                 'Tarkista sähköpostiosoite.'}
+              {apiErrors && apiErrors.fields && apiErrors.fields.email && (
+                <p>Sähköpostiosoite on jo olemassa.</p>
+              )}
             </div>
           </div>
 
@@ -300,16 +304,16 @@ const CreateAccount = ({ handleAccountCreation }) => {
         </form>
         <div className="create-account-links-container">
           <Link className="create-account-link-block" to="/login">
-            {'Olen vanha käyttäjä ja haluan kirjautua sisään.'}
+            Olen vanha käyttäjä ja haluan kirjautua sisään.
           </Link>
           <Link className="create-account-link-block" to="/registrationproblem">
-            {'Tarvitsen apua rekisteröitymisessä.'}
+            Tarvitsen apua rekisteröitymisessä.
           </Link>
           <Link className="create-account-link-block" to="/">
-            {'Tutustu tietosuojaselosteeseen.'}
+            Tutustu tietosuojaselosteeseen.
           </Link>
           <Link className="create-account-link-block" to="/">
-            {'Tutustu saavutettavuusselosteeseen.'}
+            Tutustu saavutettavuusselosteeseen.
           </Link>
         </div>
       </div>
@@ -319,6 +323,15 @@ const CreateAccount = ({ handleAccountCreation }) => {
 
 CreateAccount.propTypes = {
   handleAccountCreation: PropTypes.func.isRequired,
+  apiErrors: PropTypes.shape({
+    name: PropTypes.string,
+    errors: PropTypes.array,
+    fields: PropTypes.object,
+  }),
+}
+
+CreateAccount.defaultProps = {
+  apiErrors: { name: '', errors: [], fields: {} },
 }
 
 export default memo(CreateAccount)

--- a/src/components/CreateAccount/index.js
+++ b/src/components/CreateAccount/index.js
@@ -10,11 +10,7 @@ import ToolTipModalContainer from '../../containers/ToolTipModalContainer'
 import getAge from '../../utils/getAge'
 import './styles.scss'
 
-<<<<<<< HEAD
 const CreateAccount = ({ handleAccountCreation, apiErrors }) => {
-  const { register, handleSubmit, errors, watch } = useForm()
-=======
-const CreateAccount = ({ handleAccountCreation }) => {
   const {
     register,
     handleSubmit,
@@ -24,7 +20,6 @@ const CreateAccount = ({ handleAccountCreation }) => {
     setError,
     clearError,
   } = useForm()
->>>>>>> development
   const [rulesAccepted, setRulesAccepted] = useState(false)
   const [phoneNumberModalIsOpen, setPhoneNumberModalIsOpen] = useState(false)
   const [passwordModalIsOpen, setPasswordModalIsOpen] = useState(false)

--- a/src/components/CreateAccount/index.js
+++ b/src/components/CreateAccount/index.js
@@ -163,7 +163,7 @@ const CreateAccount = ({ handleAccountCreation, apiErrors }) => {
                 errors.email.type === 'pattern' &&
                 'Tarkista sähköpostiosoite.'}
               {apiErrors && apiErrors.fields && apiErrors.fields.email && (
-                <p>Sähköpostiosoite on jo olemassa.</p>
+                <p>Tähän sähköpostiin on liitetty jo käyttäjä.</p>
               )}
             </div>
           </div>

--- a/src/containers/CreateAccountContainer.js
+++ b/src/containers/CreateAccountContainer.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { memo, useState } from 'react'
 import PropTypes from 'prop-types'
 import uniqid from 'uniqid'
 import CreateAccount from '../components/CreateAccount'
@@ -6,6 +6,8 @@ import * as API from '../api/user/user'
 
 const CreateAccountContainer = props => {
   const { history } = props
+  const [errors, setErrors] = useState(null)
+
   const handleAccountCreation = async (
     firstname,
     lastname,
@@ -44,8 +46,11 @@ const CreateAccountContainer = props => {
         password,
       }
       if (user) {
-        await API.userSignUp(user)
-        history.push('/registration-success')
+        const res = await API.userSignUp(user)
+        if (res && res.success) {
+          history.push('/registration-success')
+        }
+        setErrors(res.error)
       }
     } catch (e) {
       // eslint-disable-next-line no-console
@@ -53,7 +58,12 @@ const CreateAccountContainer = props => {
     }
   }
 
-  return <CreateAccount handleAccountCreation={handleAccountCreation} />
+  return (
+    <CreateAccount
+      handleAccountCreation={handleAccountCreation}
+      apiErrors={errors}
+    />
+  )
 }
 
 // TODO: refactor


### PR DESCRIPTION
This resolves #190 and shows error coming from backend if user tries to register with email that already exists. 

I did not change error handling in other api calls yet, since there is no specific need for it, for now. I will change it later if needed. 

Also I think the "email already exists" is only relevant error coming from backend that we need to catch and show in front to the user. At least I did not come up with anything else that the form field validation would not already handle. If there are more, let me know. :)