### PR TITLE
Frontend/115/user account locked

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,9 +24,10 @@ import EditProfileContainer from './containers/EditProfileContainer'
 import InterestsContainer from './containers/InterestsContainer'
 import FullScreenLoading from './components/FullScreenLoading'
 import { rootStartUp as rootStartUpAction } from './store/root'
-import './styles/defaults.scss'
 import ChangeAccountInfoContainer from './containers/ChangeAccountInfoContainer'
 import RestoreAccountContainer from './containers/RestoreAccountContainer'
+import AccountLocked from './components/AccountLocked'
+import './styles/defaults.scss'
 
 class App extends Component {
   async componentDidMount() {
@@ -46,10 +47,13 @@ class App extends Component {
   }
 
   render() {
-    const { loading, user: pUser } = this.props
+    const { loading, user: pUser, mmuser } = this.props
+
     if (loading.root && localStorage.getItem('authToken')) {
-      // TODO: Nice spashscree
       return <FullScreenLoading />
+    }
+    if (!loading.root && localStorage.getItem('authToken') && !mmuser) {
+      return <AccountLocked />
     }
 
     return (
@@ -108,6 +112,11 @@ App.propTypes = {
   rootStartUp: PropTypes.func.isRequired,
   loading: PropTypes.instanceOf(Object).isRequired,
   user: PropTypes.instanceOf(Object).isRequired,
+  mmuser: PropTypes.instanceOf(Object),
+}
+
+App.defaultProps = {
+  mmuser: null,
 }
 
 const mapDispatchToProps = dispatch =>
@@ -119,9 +128,20 @@ const mapDispatchToProps = dispatch =>
   )
 
 const mapStateToProps = store => {
+  const currentUserId =
+    store &&
+    store.entities &&
+    store.entities.users &&
+    store.entities.users.currentUserId
+  const profiles =
+    store &&
+    store.entities &&
+    store.entities.users &&
+    store.entities.users.profiles
   return {
     loading: store.loading,
     user: store.user,
+    mmuser: profiles[currentUserId],
   }
 }
 

--- a/src/components/AccountLocked/index.js
+++ b/src/components/AccountLocked/index.js
@@ -1,0 +1,19 @@
+import React, { memo } from 'react'
+// import { Link } from 'react-router-dom'
+// import * as API from '../../api/user/user'
+// import handleLogout from '../../utils/userLogout'
+import './styles.scss'
+
+const AccountLocked = () => {
+  return (
+    <div className="account-locked-container">
+      <h1 className="account-locked-text">Kohdataan</h1>
+      <h3>
+        Näyttäisi, että käyttäjätilisi on tällä hetkellä pois käytöstä. Voit
+        yrittää kirjautua sisään myöhemmin uudestaan.
+      </h3>
+    </div>
+  )
+}
+
+export default memo(AccountLocked)

--- a/src/components/AccountLocked/index.js
+++ b/src/components/AccountLocked/index.js
@@ -1,10 +1,12 @@
-import React, { memo } from 'react'
-// import { Link } from 'react-router-dom'
-// import * as API from '../../api/user/user'
-// import handleLogout from '../../utils/userLogout'
+import React, { memo, useEffect } from 'react'
 import './styles.scss'
 
 const AccountLocked = () => {
+  useEffect(() => {
+    localStorage.removeItem('userId')
+    localStorage.removeItem('authToken')
+  })
+
   return (
     <div className="account-locked-container">
       <h1 className="account-locked-text">Kohdataan</h1>

--- a/src/components/AccountLocked/styles.scss
+++ b/src/components/AccountLocked/styles.scss
@@ -1,7 +1,9 @@
+@import '../../styles/colors.scss';
+
 .account-locked-container {
   width: 100%;
   height: 100%;
-  background-color: black;
+  background-color: $black;
   text-align: center;
   h3 {
     color: lightgrey;

--- a/src/components/AccountLocked/styles.scss
+++ b/src/components/AccountLocked/styles.scss
@@ -1,0 +1,14 @@
+.account-locked-container {
+  width: 100%;
+  height: 100%;
+  background-color: black;
+  text-align: center;
+  h3 {
+    color: lightgrey;
+  }
+}
+
+.account-locked-text {
+  color: white;
+  padding-top: 50vh;
+}

--- a/src/components/FullScreenLoading/styles.scss
+++ b/src/components/FullScreenLoading/styles.scss
@@ -1,7 +1,9 @@
+@import '../../styles/colors.scss';
+
 .full-screen-loading {
   width: 100%;
   height: 100%;
-  background-color: black;
+  background-color: $black;
   text-align: center;
 }
 


### PR DESCRIPTION
This implements screen for locked accounts after user tries to log in. The logic is:
1) If user can authenticate (hence has auth token stored) they still have active node user account
2) If they cannot login with mattermost user, someone has deactivated their account on purpose, and they should see a screen indicating that their account is locked for some period of time. 

This resolves #212

- [x] Locked screen

- [x] Logic to show locked screen
