### PR TITLE
Adds pinning action and icon to messages view for message reporting

### DIFF
--- a/src/components/Chat/MessageList/Message/index.js
+++ b/src/components/Chat/MessageList/Message/index.js
@@ -2,9 +2,11 @@ import React, { memo } from 'react'
 import { Link } from 'react-router-dom'
 import './styles.scss'
 import propTypes from 'prop-types'
+import ButtonContainer from '../../../ButtonContainer'
 
 const Message = props => {
   const {
+    id,
     sender,
     text,
     currentUserId,
@@ -18,6 +20,7 @@ const Message = props => {
     channelId,
     senderMmUsername,
     iconMemberStatus,
+    pinPost,
   } = props
 
   // Adds the text to be used for the date divider
@@ -122,6 +125,14 @@ const Message = props => {
                 )}
                 {!files && <p className="chat-message-content-text">{text}</p>}
               </div>
+              {currentUserId !== senderId && !directChannel && (
+                <ButtonContainer
+                  className="chat-report-message-icon"
+                  onClick={() => pinPost(id)}
+                >
+                  <i className="far fa-flag" aria-hidden="true" />
+                </ButtonContainer>
+              )}
             </div>
           </div>
         </div>
@@ -152,6 +163,8 @@ Message.propTypes = {
   channelId: propTypes.string.isRequired,
   senderMmUsername: propTypes.string,
   iconMemberStatus: propTypes.string,
+  pinPost: propTypes.func.isRequired,
+  id: propTypes.string.isRequired,
 }
 
 export default memo(Message)

--- a/src/components/Chat/MessageList/Message/styles.scss
+++ b/src/components/Chat/MessageList/Message/styles.scss
@@ -118,7 +118,7 @@
 }
 
 .chat-online-status-icon {
-  position: relative; 
+  position: relative;
   bottom: 8px;
   left: 18px;
   background-color: green;
@@ -130,7 +130,7 @@
 }
 
 .chat-offline-status-icon {
-  position: relative; 
+  position: relative;
   bottom: 8px;
   left: 18px;
   border: 1px solid $white;
@@ -142,7 +142,7 @@
 }
 
 .chat-away-status-icon {
-  position: relative; 
+  position: relative;
   bottom: 8px;
   left: 18px;
   background-color: yellow;
@@ -151,7 +151,6 @@
   border-radius: 50%;
   margin-right: 7px;
 }
-
 
 .chat-message-sender {
   margin-block-end: 0em;
@@ -199,4 +198,11 @@
 .message-image {
   height: inherit;
   width: inherit;
+}
+
+.chat-report-message-icon {
+  background: none;
+  border: none;
+  color: $orange;
+  cursor: grab;
 }

--- a/src/components/Chat/MessageList/index.js
+++ b/src/components/Chat/MessageList/index.js
@@ -13,6 +13,7 @@ const MessageList = props => {
     channelId,
     profiles,
     getStatusById,
+    pinPost,
   } = props
 
   const getIconMemberStatus = userId =>
@@ -83,6 +84,7 @@ const MessageList = props => {
                 !post.type.includes('system') && (
                   <Message
                     key={post.id}
+                    id={post.id}
                     files={post.file_ids}
                     type={post.type}
                     url={post.url}
@@ -97,6 +99,7 @@ const MessageList = props => {
                     channelId={channelId}
                     senderMmUsername={getUsernameById(post.user_id, profiles)}
                     iconMemberStatus={getIconMemberStatus(post.user_id)}
+                    pinPost={pinPost}
                   />
                 )
               )
@@ -114,6 +117,7 @@ MessageList.propTypes = {
   channelId: propTypes.string.isRequired,
   profiles: propTypes.instanceOf(Object).isRequired,
   getStatusById: propTypes.func.isRequired,
+  pinPost: propTypes.func.isRequired,
 }
 
 export default memo(MessageList)

--- a/src/components/Chat/index.js
+++ b/src/components/Chat/index.js
@@ -4,6 +4,8 @@ import MessageList from './MessageList'
 import ChatHeader from './ChatHeader'
 import UserInput from './UserInput'
 import MembersSider from './MembersSider'
+import ModalContainer from '../ModalContainer'
+import ButtonContainer from '../ButtonContainer'
 import './styles.scss'
 
 const Chat = props => {
@@ -20,9 +22,13 @@ const Chat = props => {
     statuses,
     handleLogout,
     location,
+    pinPost,
   } = props
 
   const [showSider, setShowSider] = useState(false)
+  const [pinPostModalIsOpen, setPinPostModalIsOpen] = useState(false)
+  const [afterPinModal, setAfterPinModal] = useState(false)
+  const [pinPostId, setPinPostId] = useState(null)
   const directChannel = channel.type === 'D'
 
   const toggleSider = () => setShowSider(!showSider)
@@ -83,6 +89,26 @@ const Chat = props => {
     return null
   }
 
+  const handlePinPost = id => {
+    setPinPostModalIsOpen(true)
+    setPinPostId(id)
+  }
+
+  const closePinPostModal = () => {
+    setPinPostModalIsOpen(false)
+    setPinPostId(null)
+  }
+
+  const completePinPost = id => {
+    pinPost(id)
+    closePinPostModal()
+    setAfterPinModal(true)
+  }
+
+  const closeAfterPinModal = () => {
+    setAfterPinModal(false)
+  }
+
   return (
     <div className="chat-wrapper" id="chat">
       <ChatHeader
@@ -104,6 +130,7 @@ const Chat = props => {
         channelId={channel.id}
         profiles={profiles}
         getStatusById={getStatusById}
+        pinPost={handlePinPost}
       />
       {channel.id && (
         <UserInput
@@ -125,6 +152,46 @@ const Chat = props => {
           channel={channel}
         />
       )}
+      <ModalContainer
+        modalIsOpen={pinPostModalIsOpen}
+        closeModal={closePinPostModal}
+        label="report-message-modal"
+      >
+        <h3>Haluatko ilmoittaa tämän viestin asiattomaksi?</h3>
+        <div className="report-message-buttons-wrapper">
+          <ButtonContainer
+            secondary
+            onClick={() => closePinPostModal()}
+            className="report-message-button"
+          >
+            <p>En</p>
+          </ButtonContainer>
+          <ButtonContainer
+            onClick={() => completePinPost(pinPostId)}
+            className="report-message-button"
+          >
+            <p>Haluan</p>
+          </ButtonContainer>
+        </div>
+      </ModalContainer>
+      <ModalContainer
+        modalIsOpen={afterPinModal}
+        closeModal={closeAfterPinModal}
+        label="report-message-finish-modal"
+      >
+        <i
+          className="fas fa-check-circle"
+          aria-hidden="true"
+          style={{ color: 'green', fontSize: '30px' }}
+        />
+        <h3>Kiitos! Viesti on nyt ilmoitettu asiattomaksi.</h3>
+        <ButtonContainer
+          className="report-message-finish-button"
+          onClick={closeAfterPinModal}
+        >
+          Valmis
+        </ButtonContainer>
+      </ModalContainer>
     </div>
   )
 }
@@ -142,6 +209,7 @@ Chat.propTypes = {
   statuses: PropTypes.instanceOf(Object).isRequired,
   handleLogout: PropTypes.func.isRequired,
   location: PropTypes.instanceOf(Object).isRequired,
+  pinPost: PropTypes.func.isRequired,
 }
 
 Chat.defaultProps = {

--- a/src/components/Chat/styles.scss
+++ b/src/components/Chat/styles.scss
@@ -1,0 +1,11 @@
+.report-message-buttons-wrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  button {
+    width: 110px;
+    padding: 0px 10px;
+    margin: 5px;
+  }
+}

--- a/src/containers/ChatContainer.js
+++ b/src/containers/ChatContainer.js
@@ -4,6 +4,7 @@ import { bindActionCreators } from 'redux'
 import {
   getPosts as getPostsAction,
   createPost as createPostAction,
+  pinPost as pinPostAction,
 } from 'mattermost-redux/actions/posts'
 import {
   uploadFile as uploadFileAction,
@@ -46,6 +47,7 @@ const ChatContainer = props => {
     statuses,
     matterMostLogout,
     location,
+    pinPost,
   } = props
   // Sort and filter posts, posts dependent effect
   const [currentPosts, setCurrentPosts] = useState([])
@@ -138,6 +140,7 @@ const ChatContainer = props => {
           getUserByUsername={getUserByUsername}
           handleLogout={handleLogout}
           location={location}
+          pinPost={pinPost}
         />
       )}
     </>
@@ -163,6 +166,7 @@ ChatContainer.propTypes = {
   statuses: PropTypes.instanceOf(Object).isRequired,
   matterMostLogout: PropTypes.func.isRequired,
   location: PropTypes.instanceOf(Object).isRequired,
+  pinPost: PropTypes.func.isRequired,
 }
 
 const mapStateToProps = (state, ownProps) => {
@@ -201,6 +205,7 @@ const mapDispatchToProps = dispatch =>
       removeChannelMember: removeChannelMemberAction,
       viewChannel: viewChannelAction,
       matterMostLogout: matterMostLogoutAction,
+      pinPost: pinPostAction,
     },
     dispatch
   )


### PR DESCRIPTION
This adds flag icons to message list for users to be able to report single messages. Clicking a flag icon will use mattermost pin message action, so that moderators will see a list of pinned messages in mattermost UI. From there on, moderators can decide whether to remove the message or freeze account or what.

Currently reported messages are not indicated in any way in chat. After confirming that user wants to report a message, they get confirmation modal that tells them action was successful.

This resolves #194 