### PR TITLE
frontend/267/fixSystemMessageShowing

### DIFF
--- a/src/components/Chat/MessageList/Message/index.js
+++ b/src/components/Chat/MessageList/Message/index.js
@@ -28,8 +28,8 @@ const Message = props => {
   const today = new Date().toLocaleDateString()
   const dateText = dateSent === today ? 'Tänään' : dateSent
 
-  // Checks if message is combined user activity message
-  const isSystemCombinedUserActivity = () => {
+  // Checks if message type is users leaving or joining the channel
+  const isUserLeavingOrJoiningChannel = () => {
     if (type === 'system_join_channel' || type === 'system_leave_channel') {
       return true
     }
@@ -45,7 +45,7 @@ const Message = props => {
   const messageContentClassList = [
     'chat-message-content',
     currentUserId === senderId ? 'content-sent' : 'content-received',
-    isSystemCombinedUserActivity() ? 'content-system-combined' : '',
+    isUserLeavingOrJoiningChannel() ? 'content-system-message' : '',
   ]
 
   useEffect(() => {
@@ -147,7 +147,7 @@ const Message = props => {
               </div>
               {currentUserId !== senderId &&
                 !directChannel &&
-                !isSystemCombinedUserActivity() && (
+                !isUserLeavingOrJoiningChannel() && (
                   <ButtonContainer
                     className="chat-report-message-icon"
                     onClick={() => pinPost(id)}

--- a/src/components/Chat/MessageList/Message/index.js
+++ b/src/components/Chat/MessageList/Message/index.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { memo, useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import './styles.scss'
 import propTypes from 'prop-types'
@@ -23,14 +23,18 @@ const Message = props => {
     pinPost,
   } = props
 
+  const [messageText, setMessageText] = useState(text)
   // Adds the text to be used for the date divider
   const today = new Date().toLocaleDateString()
   const dateText = dateSent === today ? 'Tänään' : dateSent
 
   // Checks if message is combined user activity message
-  const isSystemCombinedUserActivity = () =>
-    type === 'system_combined_user_activity'
-
+  const isSystemCombinedUserActivity = () => {
+    if (type === 'system_join_channel' || type === 'system_leave_channel') {
+      return true
+    }
+    return false
+  }
   // Get message wrapper classes
   const messageWrapperClassList = [
     'chat-message-wrapper',
@@ -43,6 +47,20 @@ const Message = props => {
     currentUserId === senderId ? 'content-sent' : 'content-received',
     isSystemCombinedUserActivity() ? 'content-system-combined' : '',
   ]
+
+  useEffect(() => {
+    if (type === 'system_join_channel') {
+      if (senderId === currentUserId) {
+        setMessageText('Sinä liityit kanavalle.')
+      } else if (sender === 'Käyttäjä poistunut') {
+        setMessageText(`Käyttäjä poistunut.`)
+      } else {
+        setMessageText(`${sender} liittyi kanavalle.`)
+      }
+    } else if (type === 'system_leave_channel') {
+      setMessageText(`${sender} poistui kanavalta.`)
+    }
+  }, [])
 
   return (
     <>
@@ -119,20 +137,24 @@ const Message = props => {
                       />
                     </Link>
                     <p className="image-message-content-text chat-message-content-text">
-                      {text}
+                      {messageText}
                     </p>
                   </>
                 )}
-                {!files && <p className="chat-message-content-text">{text}</p>}
+                {!files && (
+                  <p className="chat-message-content-text">{messageText}</p>
+                )}
               </div>
-              {currentUserId !== senderId && !directChannel && (
-                <ButtonContainer
-                  className="chat-report-message-icon"
-                  onClick={() => pinPost(id)}
-                >
-                  <i className="far fa-flag" aria-hidden="true" />
-                </ButtonContainer>
-              )}
+              {currentUserId !== senderId &&
+                !directChannel &&
+                !isSystemCombinedUserActivity() && (
+                  <ButtonContainer
+                    className="chat-report-message-icon"
+                    onClick={() => pinPost(id)}
+                  >
+                    <i className="far fa-flag" aria-hidden="true" />
+                  </ButtonContainer>
+                )}
             </div>
           </div>
         </div>

--- a/src/components/Chat/MessageList/Message/styles.scss
+++ b/src/components/Chat/MessageList/Message/styles.scss
@@ -112,7 +112,7 @@
 
 .content-system-combined {
   background-color: white;
-  color: gray;
+  color: #666464;
   border: none;
   width: 100%;
 }

--- a/src/components/Chat/MessageList/Message/styles.scss
+++ b/src/components/Chat/MessageList/Message/styles.scss
@@ -110,7 +110,7 @@
   justify-content: flex-end;
 }
 
-.content-system-combined {
+.content-system-message {
   background-color: white;
   color: #666464;
   border: none;

--- a/src/components/Chat/MessageList/index.js
+++ b/src/components/Chat/MessageList/index.js
@@ -72,16 +72,14 @@ const MessageList = props => {
           posts
             .filter(
               p =>
-                p.type !== 'system_join_channel' &&
-                p.type !== 'system_leave_channel' &&
                 p.type !== 'system_purpose_change'
+                // p.sender !== 'Käyttäjä poistunut'
             )
             .map(post => {
               const timestampValues = setTimeStampValues(post)
               return (
                 post &&
-                post.user_id &&
-                !post.type.includes('system') && (
+                post.user_id && (
                   <Message
                     key={post.id}
                     id={post.id}
@@ -102,7 +100,7 @@ const MessageList = props => {
                     pinPost={pinPost}
                   />
                 )
-              )
+            )
             })}
       </div>
     </div>

--- a/src/components/Groups/Group/index.js
+++ b/src/components/Groups/Group/index.js
@@ -63,27 +63,33 @@ const Group = props => {
         )}
         {channel.name !== 'town-square' ? (
           <div className="group-current-members">
-            {activeMembers.map(member => (
-              <Member
-                key={`group-${member.id}`}
-                nickname={member.nickname || member.username}
-                currentUserId={currentUserId}
-                userId={member.id}
-              />
-            ))}
+            {activeMembers &&
+              activeMembers.map(member => (
+                <Member
+                  key={`group-${member.id}`}
+                  nickname={member.nickname || member.username}
+                  currentUserId={currentUserId}
+                  userId={member.id}
+                />
+              ))}
           </div>
         ) : (
           <p>Tämä ryhmä on yleistä palautetta varten.</p>
         )}
       </div>
-      {unreadCount > 0 && (
+      {unreadCount === 1 && (
         <div className="group-unreads-text">
-          <li>{`${unreadCount} uutta viestiä`}</li>
+          <li>{`${unreadCount} uusi ilmoitus`}</li>
+        </div>
+      )}
+      {unreadCount > 1 && (
+        <div className="group-unreads-text">
+          <li>{`${unreadCount} uutta ilmoitusta`}</li>
         </div>
       )}
       {unreadCount <= 0 && (
         <div className="group-unreads-text no-unreads">
-          <p>Ei uusia viestejä</p>
+          <p>Ei uusia ilmoituksia</p>
         </div>
       )}
     </Link>


### PR DESCRIPTION
Translates system messages to appropriate Finnish versions and only shows the system messages that are shown in total message count. The user has left / joined channel messages are now shown. If the user leaves the entire service, there is no separate message to show that the user has also left the channel. Not sure if there should be. The system messages for user who has left the channel just show "Käyttäjä poistunut". This also resolves #214.

I also made the system message font slightly darker (same as timestamps now) for accessibility.