### PR TITLE
Frontend/318/TutorialFixes

### DIFF
--- a/src/components/Friends/Friend/index.js
+++ b/src/components/Friends/Friend/index.js
@@ -172,7 +172,7 @@ const Friend = props => {
               )}
             </Link>
             <ButtonContainer
-              className="icon-btn"
+              className="icon-btn block-user-icon-btn"
               onClick={() => setShowModal(true)}
             >
               <i

--- a/src/components/Friends/Friend/styles.scss
+++ b/src/components/Friends/Friend/styles.scss
@@ -7,6 +7,8 @@
 .block-user-icon {
   height: 100%;
   color: #3a3a3a;
+  padding-top: 5px;
+  margin-left: 5px;
 }
 .blocked-friend-text-content {
   color: grey;

--- a/src/components/Friends/Friend/styles.scss
+++ b/src/components/Friends/Friend/styles.scss
@@ -8,7 +8,10 @@
   height: 100%;
   color: #3a3a3a;
   padding-top: 5px;
-  margin-left: 5px;
+  
+}
+.block-user-icon-btn {
+  margin: 0 10px 0 10px;
 }
 .blocked-friend-text-content {
   color: grey;
@@ -50,6 +53,7 @@
   flex-wrap: nowrap;
   align-items: center;
   justify-content: center;
+  margin-right: 12px;
 }
 .friend-box {
   width: 100%;
@@ -87,8 +91,9 @@
   display: flex;
   flex-flow: row nowrap;
   align-items: center;
-  justify-content: space-between;
+  justify-content: space-around;
   align-content: center;
+  margin-right: 5px;
   border-bottom: 1px solid #9a9a9a;
 }
 .friend-text-content {

--- a/src/components/Friends/styles.scss
+++ b/src/components/Friends/styles.scss
@@ -32,8 +32,9 @@
   background-color: transparent;
   border: none; 
   position: absolute;
-  left: 35px;
+  right: 150px;
   bottom: 15px;
+  outline: none;
 }
 
 .no-friends-yet-header {

--- a/src/components/Groups/styles.scss
+++ b/src/components/Groups/styles.scss
@@ -24,6 +24,7 @@
   background-color: transparent;
   border: none; 
   position: absolute;
-  left: 50px;
+  right: 150px;
   bottom: 15px;
+  outline: none;
 }

--- a/src/components/RegistrationFlow/StepButton/styles.scss
+++ b/src/components/RegistrationFlow/StepButton/styles.scss
@@ -35,7 +35,7 @@
   white-space: nowrap;
   font-size: 0.875rem;
   color: white;
-  background-color: black;
+  background-color: #666464;
   outline: none;
   font-family: 'Poppins', sans-serif;
   font-size: 16px;
@@ -44,7 +44,6 @@
   border: solid 1px #f5a623;
   border-radius: 30px;
   text-decoration: none;
-  opacity: 0.5;
 }
 
 .skip-button {

--- a/src/components/Tutorial/index.js
+++ b/src/components/Tutorial/index.js
@@ -22,14 +22,16 @@ const Tutorial = props => {
       borderRadius: '30px',
       padding: '5px 10px',
       marginRight: '30px',
+      outline: 'none',
     },
     buttonBack: {
       marginLeft: 'auto',
       fontFamily: 'Poppins',
-      fontSize: '14px',
+      fontSize: '16px',
       borderRadius: '30px',
       padding: '5px 10px',
       color: 'black',
+      outline: 'none',
     },
     buttonSkip: {
       marginLeft: 'auto',
@@ -41,6 +43,9 @@ const Tutorial = props => {
     },
     buttonClose: {
       display: 'none',
+    },
+    spotlight: {
+      backgroundColor: 'transparent',
     },
   }
 


### PR DESCRIPTION
Made buttons in tutorial similar, removed outline from buttons and changed the background colour in spotlight to transparent since it was highlighting too much of the area for the bot on bigger displays.  Couldn't figure out how to make the tutorial navigate the steps in reverse if the user goes back from Friends view (tried reversing the steps if going back but then ran into trouble getting the back button in bot to go back..) so it was decided that it would maybe be fixed at a later time.

Fixes also back button in registration flow: Changed from black with opacity 0.5 to background gray. Also fixes the ellipsis in Friends view not having enough margin making it hard to hit sometimes.