### PR TITLE
changed how mm-username is created

### DIFF
--- a/src/containers/CreateAccountContainer.js
+++ b/src/containers/CreateAccountContainer.js
@@ -36,7 +36,7 @@ const CreateAccountContainer = props => {
     // Mattermot username must begin with a letter and contain between 3 and 22 characters
     // including numbers, lowercase letters, and the symbols ".", "-", and "_".
 
-    let username = `${uniqid.process()}`.concat(email.split('@')[0])
+    let username = `${uniqid('-')}`
     if (username.length > 22) {
       username = username.slice(0, 22)
     }


### PR DESCRIPTION
Simply removes email from mm-username when it is created. This was done because sometimes when the page is being loaded, the username might briefly be seen before the nicknames appear. Since the user's emails is personal information and should never be shown, this is a quick fix to that problem. When there's more time, it would be good to look into how to ensure that the only thing user sees is the nickname. 