### PR TITLE
adding delete-string to voice or video message shows 'message deleted…

### DIFF
--- a/src/components/Chat/ChatHeader/styles.scss
+++ b/src/components/Chat/ChatHeader/styles.scss
@@ -11,6 +11,7 @@
   z-index: 2000;
   border-bottom: 1px solid $orange;
   overflow: visible;
+  background-color: white;
   @media (max-width: 360px) {
     height: 15%;
   }

--- a/src/components/Chat/MembersSider/Member/index.js
+++ b/src/components/Chat/MembersSider/Member/index.js
@@ -19,23 +19,7 @@ const Member = props => {
   }
 
   if (isSystemAdmin(userId, profiles) || isTeamAdmin(userId, teams)) {
-    return (
-      <div className="chat-header-members-sider-member">
-        <div>
-          <div
-            className="label chat-message-sender-icon"
-            style={{
-              backgroundColor: 'black',
-              color: 'white',
-            }}
-          >
-            K
-          </div>
-        </div>
-        <span className={iconMemberStatus} />
-        <span>Valvoja</span>
-      </div>
-    )
+    return <></>
   }
   return (
     <div className="chat-header-members-sider-member">

--- a/src/components/Chat/MessageList/Message/index.js
+++ b/src/components/Chat/MessageList/Message/index.js
@@ -229,6 +229,9 @@ const Message = props => {
                       />
                     </div>
                   )}
+                {files && deleted && (
+                  <p className="chat-message-content-text">{messageText}</p>
+                )}
                 {!files && (
                   <p className="chat-message-content-text">{messageText}</p>
                 )}


### PR DESCRIPTION
Deleting a message using the predetermined string did not handle the situation where voice or image message was deleted. Added this so if team admin adds the string, the ui will only show "message deleted". Also added background:white to header to get rid of Safari issues with messages showing "through" the header. 

And removed team/system admins info from members-sider.