### PR TITLE
Frontend/319/check link error appears at wrong times

### DIFF
--- a/src/components/Chat/MessageList/Message/styles.scss
+++ b/src/components/Chat/MessageList/Message/styles.scss
@@ -213,6 +213,7 @@
 .message-image {
   height: inherit;
   width: inherit;
+  max-width: 100%;
 }
 
 .chat-report-message-icon {

--- a/src/components/LogIn/index.js
+++ b/src/components/LogIn/index.js
@@ -27,7 +27,7 @@ const LogIn = props => {
     <main className="login-container">
       <h1 className="main-title">Kohdataan</h1>
       {uuid && <p id="message-text">Kiitos sähköpostin vahvistamisesta.</p>}
-      {linkError && <p id="message-text">Tarkasta linkki.</p>}
+      {linkError && !errors.email && <p id="message-text">Tarkasta linkki.</p>}
       {textToAdd && <p id="message-text">{textToAdd}</p>}
       <div className="login-fields-container">
         <h2 className="login-title">KIRJAUTUMINEN</h2>


### PR DESCRIPTION
Fixes error where Tarkasta linkki -error was shown also when the user misspelled email or password. That is fixed by checking if there is a link error and if there are errors in email (which also checks for password, since both validation errors are triggered if one of these is misspelled).  

Also fixed a small bug #336 where image in message could overflow the container (image posted by test user) by adding max-width. This should stay inside the container now.

<img width="574" alt="Screenshot 2020-03-19 at 12 06 50" src="https://user-images.githubusercontent.com/33627243/77081736-c0c7ff00-6a03-11ea-81b3-85ed821969ea.png">

