### PR TITLE
frontend/321/directChannelUserLeftMessageFix

### DIFF
--- a/src/components/Chat/index.js
+++ b/src/components/Chat/index.js
@@ -157,7 +157,7 @@ const Chat = props => {
           filesData={filesData}
         />
       )}
-      {channel.id && getDeleteAt() !== 0 && directChannel && (
+      {channel.id && getDeleteAt() && getDeleteAt() !== 0 && directChannel && (
         <div className="inactive-userinput-field">
           <p>Et voi lähettää viestiä poistuneelle käyttäjälle.</p>
         </div>


### PR DESCRIPTION
There apparently was a bug that prevented people from sending private messages even if other person has not left the system, i could not reproduce the bug but i added a check that should be the only way it could happen.