### PR TITLE
made bot windows smaller

### DIFF
--- a/src/components/BottomNavigationBot/PageInformation/styles.scss
+++ b/src/components/BottomNavigationBot/PageInformation/styles.scss
@@ -1,11 +1,13 @@
 .page-info-text-content {
   white-space: pre-wrap;
   text-align: left;
+  padding: 2px;
+  line-height: 1.2em;
 } 
 
 .page-information-container {
   min-height: 75vh;
-  width: 65vw;
+  max-width: 400px;
   display: flex;
   flex-direction: column;
   justify-content: space-around;

--- a/src/components/ModalContainer/index.js
+++ b/src/components/ModalContainer/index.js
@@ -17,7 +17,8 @@ const customStyles = {
     borderRadius: '5px',
     textAlign: 'center',
     maxHeight: '80vh',
-    minWidth: '40vh',
+    minWidth: '30vh',
+    maxWidth: '400px',
   },
   overlay: {
     position: 'fixed',
@@ -42,7 +43,7 @@ const customStylesEditModal = {
     minHeight: '30vh',
     maxHeight: '80vh',
     width: '80vw',
-    maxWidth: '660px',
+    maxWidth: '400px',
   },
   overlay: {
     position: 'fixed',


### PR DESCRIPTION
Decreased bot window sizes so that the modals won't be too big on desktop, and also that they would be the same size. Also increased line-height and added a bit of padding for improved readability.