### PR TITLE
frontend/350/botModalAccessibility

### DIFF
--- a/src/components/BottomNavigationBot/index.js
+++ b/src/components/BottomNavigationBot/index.js
@@ -83,14 +83,12 @@ const BottomNavigationBot = forwardRef((props, ref) => {
               />
             </ModalContainer>
           </div>
-          <hr />
+          <hr aria-hidden="true" />
           <div className="modal-content">
             <div className="modal-item">
               <i className="fas fa-life-ring modal-icon" aria-hidden="true" />
               <ButtonContainer
                 className="bot-link"
-                role="link"
-                tabIndex={0}
                 onClick={openSendMessageModal}
               >
                 Lähetä valvojalle viesti
@@ -107,30 +105,25 @@ const BottomNavigationBot = forwardRef((props, ref) => {
               </ModalContainer>
             </div>
           </div>
-          <hr />
-          <div className="modal-item inactive-item">
+          <hr aria-hidden="true" />
+          <div className="modal-item inactive-item" aria-hidden="true">
             <i className="fas fa-check-square modal-icon" aria-hidden="true" />
             Palvelun säännöt
           </div>
-          <hr />
-          <div className="modal-item inactive-item">
+          <hr aria-hidden="true" />
+          <div className="modal-item inactive-item" aria-hidden="true">
             <i className="fas fa-info-circle modal-icon" aria-hidden="true" />
             Yleiset ohjeet
           </div>
-          <hr />
+          <hr aria-hidden="true" />
           <div className="modal-item">
             <Link to="/account" onClick={() => closeModal(setShowBot)}>
               <i className="fas fa-cog modal-icon" aria-hidden="true" />
               Rekisteröitymis&shy;tiedot
             </Link>
           </div>
-          <hr />
-          <ButtonContainer
-            className="bot-link"
-            role="link"
-            tabIndex={0}
-            onClick={openLogOutModal}
-          >
+          <hr aria-hidden="true" />
+          <ButtonContainer className="bot-link" onClick={openLogOutModal}>
             <i className="fas fa-sign-out-alt modal-icon" aria-hidden="true" />
             Kirjaudu ulos
           </ButtonContainer>


### PR DESCRIPTION
Made the bot modal more accessible by adding aria-hide to some elements that don't need to be seen by screen readers, and removing role=link from some places where it was not meaningful. 