### PR TITLE
frontend/359/inputTextShowsBelowModal

### DIFF
--- a/src/components/Chat/FilePreview/index.js
+++ b/src/components/Chat/FilePreview/index.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { memo, useState, useEffect } from 'react'
 import TextareaAutosize from 'react-autosize-textarea'
 import PropTypes from 'prop-types'
 import ReactPlayer from 'react-player'
@@ -15,6 +15,16 @@ const FilePreview = props => {
     filesData,
     orientation,
   } = props
+
+  useEffect(() => {
+    handleChange('')
+  }, [handleChange])
+
+  const [msg, setMsg] = useState(message)
+
+  const addCaption = async e => {
+    handleSubmit(e, msg)
+  }
 
   const getOrientationClassName = () => {
     let className
@@ -55,6 +65,7 @@ const FilePreview = props => {
         <ButtonContainer
           className="image-preview-close-modal-button go-back-button"
           onClick={closeModal}
+          label="Sulje"
         >
           {' '}
         </ButtonContainer>
@@ -82,21 +93,26 @@ const FilePreview = props => {
       <div className="image-preview-form">
         <div className="image-preview-user-input-wrapper">
           <form
-            onSubmit={handleSubmit}
+            onSubmit={e => addCaption(e)}
             className="image-preview-user-input-content"
           >
             <TextareaAutosize
               className="image-preview-user-input-text-field"
               id="image-message"
               type="text"
-              value={message}
-              onChange={handleChange}
+              value={msg}
+              onChange={e => setMsg(e.target.value)}
               placeholder="Kirjoita viesti"
               maxRows={3}
               rows={1}
-              aria-label="message text"
+              aria-label="Lisää kuvateksti"
             />
-            <button type="submit" className="send-message-button" tabIndex="0">
+            <button
+              type="submit"
+              className="send-message-button"
+              tabIndex="0"
+              aria-label="Lähetä"
+            >
               {}
             </button>
           </form>

--- a/src/components/Chat/UserInput/index.js
+++ b/src/components/Chat/UserInput/index.js
@@ -166,7 +166,7 @@ const UserInput = props => {
       <ModalContainer
         modalIsOpen={modalIsOpen}
         closeModal={closeModal}
-        label="Esikatselu-dialogi"
+        label={!isRecording ? 'Esikatselu' : 'Ääniviestin lähetys'}
         isLong
         className="image-preview-modal"
         overlayClassName="image-preview-modal-overlay"

--- a/src/components/Chat/UserInput/index.js
+++ b/src/components/Chat/UserInput/index.js
@@ -18,6 +18,7 @@ const UserInput = props => {
   const [errorModalIsOpen, setErrorModalIsOpen] = useState(false)
   const [orientation, setOrientation] = useState(0)
 
+
   const getExifData = file => {
     // get Exif data for file if it exists.
     // Exif data is used to rotate the image to the correct orientation.
@@ -47,11 +48,15 @@ const UserInput = props => {
   const isEmpty = str => {
     return str.replace(/^\s+|\s+$/g, '').length === 0
   }
-  const handleSubmit = async e => {
+  const handleSubmit = async (e, msg) => {
     e.preventDefault()
+    let messageToUse = msg
+    if (msg === '' || msg === undefined) {
+      messageToUse = message
+    }
     const post = {
       channel_id: channel.id,
-      message,
+      message: messageToUse,
       file_ids: fileId !== '' ? [fileId] : null,
     }
     if ((message && !isEmpty(message)) || fileId !== '') {
@@ -65,6 +70,7 @@ const UserInput = props => {
   const handleChange = e => {
     setMessage(e.target.value)
   }
+
   const addFile = async e => {
     setIsUploading(true)
     const channelId = channel.id
@@ -160,7 +166,7 @@ const UserInput = props => {
       <ModalContainer
         modalIsOpen={modalIsOpen}
         closeModal={closeModal}
-        label="image-preview-dialog"
+        label="Esikatselu-dialogi"
         isLong
         className="image-preview-modal"
         overlayClassName="image-preview-modal-overlay"
@@ -182,7 +188,7 @@ const UserInput = props => {
           <FilePreview
             handleSubmit={handleSubmit}
             message={message}
-            handleChange={handleChange}
+            handleChange={setMessage}
             fileId={fileId}
             closeModal={closeModal}
             filesData={filesData}


### PR DESCRIPTION
If a user adds an image, the text they possibly started writing is now copied from input field and shows in file preview input, but not in the original input. If they cancel sending the message, the original input remains cleared. I decided not to move focus to input after all, since I felt maybe it's better for screen reader users after all to first go to menu. This can be changed if necessary. Also added in some missing aria-labels to buttons in file preview, and renamed modal depending on if the user is recording audio or not.