### PR TITLE
frontend/382/removed Tarkasta linkki error

### DIFF
--- a/src/components/LogIn/index.js
+++ b/src/components/LogIn/index.js
@@ -27,9 +27,6 @@ const LogIn = props => {
     <main className="login-container">
       <h1 className="main-title">Kohdataan</h1>
       {uuid && <p id="message-text">Kiitos sähköpostin vahvistamisesta.</p>}
-      {error && error === 'uuidLinkError' && (
-        <p id="message-text">Tarkasta linkki.</p>
-      )}
       {error && error === 'cookiesNotAccepted' && (
         <p id="message-text">
           Jos haluat käyttää Kohdataan-somea, sinun täytyy hyväksyä evästeiden

--- a/src/containers/LogInContainer.js
+++ b/src/containers/LogInContainer.js
@@ -43,7 +43,6 @@ const LogInContainer = props => {
           setUuidValid(true)
         } else {
           setUuidValid(false)
-          setError('uuidLinkError')
         }
       })
     }


### PR DESCRIPTION
Removed error where the user is shown "Tarkasta linkki" if the link is copied wrong. This was done because it was confusing that the user can use an old link and login successfully, but they would get the error, and this error would also show up when the user updated the page or entered wrong information before login. Backend branch 148 fixes the latter behaviour, so if the link is correct but unused, the user is always shown the "kiitos sähköpostin vahvistamisesta" error.