### PR TITLE
Frontend/383/bottom navigation should disappear

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -51,7 +51,6 @@ class App extends Component {
 
   render() {
     const { loading, user: pUser, mmuser } = this.props
-    console.log(pUser)
     if (loading.root && localStorage.getItem('authToken')) {
       return <FullScreenLoading />
     }
@@ -59,7 +58,8 @@ class App extends Component {
       !loading.root &&
       localStorage.getItem('authToken') &&
       !mmuser &&
-      pUser
+      pUser &&
+      !pUser.deleteAt
     ) {
       return <AccountLocked />
     }
@@ -115,7 +115,9 @@ class App extends Component {
         {localStorage.getItem('authToken') && pUser && pUser.deleteAt && (
           <RestoreAccountContainer />
         )}
-        {localStorage.getItem('authToken') && <BottomNavigationContainer />}
+        {localStorage.getItem('authToken') && pUser && !pUser.deleteAt && (
+          <BottomNavigationContainer />
+        )}
         {!document.cookie.includes('CookieConsent=true') && <CookieContainer />}
       </Container>
     )

--- a/src/App.js
+++ b/src/App.js
@@ -51,11 +51,16 @@ class App extends Component {
 
   render() {
     const { loading, user: pUser, mmuser } = this.props
-
+    console.log(pUser)
     if (loading.root && localStorage.getItem('authToken')) {
       return <FullScreenLoading />
     }
-    if (!loading.root && localStorage.getItem('authToken') && !mmuser) {
+    if (
+      !loading.root &&
+      localStorage.getItem('authToken') &&
+      !mmuser &&
+      pUser
+    ) {
       return <AccountLocked />
     }
 
@@ -107,10 +112,10 @@ class App extends Component {
         <PrivateRoute path="/chat/:id/:fileId" component={ViewImageContainer} />
         <PrivateRoute path="/edit-interests" component={InterestsContainer} />
         <PrivateRoute path="/account" component={ChangeAccountInfoContainer} />
-        {localStorage.getItem('authToken') && <BottomNavigationContainer />}
         {localStorage.getItem('authToken') && pUser && pUser.deleteAt && (
           <RestoreAccountContainer />
         )}
+        {localStorage.getItem('authToken') && <BottomNavigationContainer />}
         {!document.cookie.includes('CookieConsent=true') && <CookieContainer />}
       </Container>
     )

--- a/src/components/Account/DeleteAccountModal/index.js
+++ b/src/components/Account/DeleteAccountModal/index.js
@@ -5,7 +5,12 @@ import ButtonContainer from '../../ButtonContainer'
 import './styles.scss'
 
 const DeleteAccountModal = props => {
-  const { showModal, deleteUser, closeModal, deleteError } = props
+  const { showModal, deleteUser, closeModal, deleteError, history } = props
+
+  const handleDelete = () => {
+    deleteUser()
+    history.push('/login')
+  }
 
   return (
     <div className="leave-channel-modal-wrapper">
@@ -32,7 +37,7 @@ const DeleteAccountModal = props => {
 
           <ButtonContainer
             className="account-delete-button"
-            onClick={deleteUser}
+            onClick={handleDelete}
           >
             Kyllä
           </ButtonContainer>
@@ -55,6 +60,7 @@ DeleteAccountModal.propTypes = {
   deleteUser: propTypes.func.isRequired,
   closeModal: propTypes.func.isRequired,
   deleteError: propTypes.string,
+  history: propTypes.instanceOf(Object).isRequired,
 }
 
 DeleteAccountModal.defaultProps = {

--- a/src/components/Account/index.js
+++ b/src/components/Account/index.js
@@ -35,7 +35,6 @@ const Account = props => {
       if (res && res.success) {
         localStorage.removeItem('userId')
         localStorage.removeItem('authToken')
-        history.push('/')
       } else if (res && res.message) {
         setDeleteError(res.message)
       }
@@ -174,6 +173,7 @@ const Account = props => {
         closeModal={() => setShowDeleteModal(false)}
         deleteUser={handleDeleteUser}
         deleteError={deleteError}
+        history={history}
       />
     </div>
   )

--- a/src/components/Account/index.js
+++ b/src/components/Account/index.js
@@ -66,7 +66,7 @@ const Account = props => {
   }
 
   return (
-    <div className="account-update-container">
+    <main className="account-update-container">
       <div className="account-header">
         <h1>Muokkaa tietojasi</h1>
         <ButtonContainer
@@ -77,9 +77,7 @@ const Account = props => {
         </ButtonContainer>
       </div>
       <div className="account-info-text">
-        <h3>
-          Nämä tiedot näkyvät vain sinulle. Kaikki tiedot ovat pakollisia.
-        </h3>
+        <p>Nämä tiedot näkyvät vain sinulle. Kaikki tiedot ovat pakollisia.</p>
       </div>
       <div className="account-box-outer">
         <div className="account-box-inner">
@@ -87,6 +85,7 @@ const Account = props => {
           <ButtonContainer
             className="account-edit-button"
             onClick={() => openModal('firstname')}
+            label="Muokkaa etunimeä"
           >
             Muokkaa
           </ButtonContainer>
@@ -99,6 +98,7 @@ const Account = props => {
           <ButtonContainer
             className="account-edit-button"
             onClick={() => openModal('lastname')}
+            label="Muokkaa sukunimeä"
           >
             Muokkaa
           </ButtonContainer>
@@ -111,6 +111,7 @@ const Account = props => {
           <ButtonContainer
             className="account-edit-button"
             onClick={() => openModal('email')}
+            label="Muokkaa sähköpostia"
           >
             Muokkaa
           </ButtonContainer>
@@ -123,6 +124,7 @@ const Account = props => {
           <ButtonContainer
             className="account-edit-button"
             onClick={() => openModal('phoneNumber')}
+            label="Muokkaa puhelinnumeroa"
           >
             Muokkaa
           </ButtonContainer>
@@ -135,6 +137,7 @@ const Account = props => {
           <ButtonContainer
             className="account-edit-button"
             onClick={() => openModal('password')}
+            label="Muokkaa salasanaa"
           >
             Muokkaa
           </ButtonContainer>
@@ -175,7 +178,7 @@ const Account = props => {
         deleteError={deleteError}
         history={history}
       />
-    </div>
+    </main>
   )
 }
 

--- a/src/components/Account/styles.scss
+++ b/src/components/Account/styles.scss
@@ -35,6 +35,10 @@
   font-size: 18px;
 }
 
+.account-info-text {
+  font-size: 1.17em;
+}
+
 .account-header {
   text-align: center;
   display: flex;
@@ -60,7 +64,7 @@
 }
 
 .account-delete-button {
-  color: red;
+  color: black;
   min-width: 230px;
   align-self: center;
   height: 42px;
@@ -87,7 +91,7 @@
 }
 
 .delete-text {
-  color: red;
+  color: black;
 }
 
 .delete-box {

--- a/src/components/ModalContainer/index.js
+++ b/src/components/ModalContainer/index.js
@@ -161,7 +161,7 @@ const ModalContainer = props => {
       style={getStyles()}
       role="dialog"
       aria={{
-        labelledby: label,
+        label,
         modal: true,
       }}
     >

--- a/src/components/RestoreAccount/index.js
+++ b/src/components/RestoreAccount/index.js
@@ -5,11 +5,12 @@ import ModalContainer from '../ModalContainer'
 import ButtonContainer from '../ButtonContainer'
 
 const RestoreAccount = props => {
-  const { handleRestore, handleDeleteNow } = props
+  const { handleRestore, handleDeleteNow, history } = props
   const [modalIsOpen, setModalIsOpen] = useState(true)
   const handleDelete = () => {
     handleDeleteNow()
     setModalIsOpen(false)
+    history.push('/login')
   }
   return (
     <ModalContainer
@@ -40,6 +41,7 @@ const RestoreAccount = props => {
 RestoreAccount.propTypes = {
   handleRestore: propTypes.func.isRequired,
   handleDeleteNow: propTypes.func.isRequired,
+  history: propTypes.instanceOf(Object).isRequired,
 }
 
 export default memo(RestoreAccount)

--- a/src/components/RestoreAccount/index.js
+++ b/src/components/RestoreAccount/index.js
@@ -5,12 +5,11 @@ import ModalContainer from '../ModalContainer'
 import ButtonContainer from '../ButtonContainer'
 
 const RestoreAccount = props => {
-  const { handleRestore, handleDeleteNow, history } = props
+  const { handleRestore, handleDeleteNow } = props
   const [modalIsOpen, setModalIsOpen] = useState(true)
   const handleDelete = () => {
     handleDeleteNow()
     setModalIsOpen(false)
-    history.push('/login')
   }
   return (
     <ModalContainer
@@ -41,7 +40,6 @@ const RestoreAccount = props => {
 RestoreAccount.propTypes = {
   handleRestore: propTypes.func.isRequired,
   handleDeleteNow: propTypes.func.isRequired,
-  history: propTypes.instanceOf(Object).isRequired,
 }
 
 export default memo(RestoreAccount)

--- a/src/containers/RestoreAccountContainer.js
+++ b/src/containers/RestoreAccountContainer.js
@@ -19,6 +19,7 @@ const RestoreAccountContainer = props => {
       if (res && res.success) {
         localStorage.removeItem('userId')
         localStorage.removeItem('authToken')
+        history.push('/')
       }
     } catch (e) {
       // eslint-disable-next-line no-console

--- a/src/containers/RestoreAccountContainer.js
+++ b/src/containers/RestoreAccountContainer.js
@@ -19,7 +19,6 @@ const RestoreAccountContainer = props => {
       if (res && res.success) {
         localStorage.removeItem('userId')
         localStorage.removeItem('authToken')
-        history.push('/')
       }
     } catch (e) {
       // eslint-disable-next-line no-console
@@ -31,6 +30,7 @@ const RestoreAccountContainer = props => {
     <RestoreAccount
       handleRestore={restoreUserAccount}
       handleDeleteNow={handleDeleteUserNow}
+      history={history}
     />
   )
 }


### PR DESCRIPTION
The nav bar would remain below after user leaves the service.  The nav menu can't be used after leaving, but it hides some links and looks funny of course. Also the Account Locked screen was shown after I'd left the service for good. This pr tries to fix those issues but it still doesn't work reliably. I tried to fix this by moving the redirect (which seemed to help some) and adding condition for AccountLocked (which seems to work now). If you have ideas on why this sometimes works and sometimes doesn't, please tell :)

Also added some accessibility fixes to Account edit page.