### PR TITLE
Frontend/navigation and modal zindex hotfix

### DIFF
--- a/src/components/BottomNavigation/styles.scss
+++ b/src/components/BottomNavigation/styles.scss
@@ -23,4 +23,5 @@
   left: 0;
   display: flex;
   justify-content: center;
+  z-index: 3000;
 }

--- a/src/components/ModalContainer/index.js
+++ b/src/components/ModalContainer/index.js
@@ -22,7 +22,7 @@ const customStyles = {
   },
   overlay: {
     position: 'fixed',
-    zIndex: '2000',
+    zIndex: '4000',
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
 }
@@ -47,7 +47,7 @@ const customStylesEditModal = {
   },
   overlay: {
     position: 'fixed',
-    zIndex: '2000',
+    zIndex: '4000',
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
 }
@@ -72,7 +72,7 @@ const customStylesTutorial = {
   },
   overlay: {
     position: 'fixed',
-    zIndex: '2000',
+    zIndex: '4000',
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
 }
@@ -96,7 +96,7 @@ const customStylesLong = {
   },
   overlay: {
     position: 'fixed',
-    zIndex: '2000',
+    zIndex: '4000',
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
 }
@@ -123,7 +123,7 @@ const customStylesCookie = {
   },
   overlay: {
     position: 'fixed',
-    zIndex: '2000',
+    zIndex: '4000',
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
 }


### PR DESCRIPTION
After we moved bottom navigation on top of the html stack, the z-index magic was not working for group suggestions, since css transforms puts those on top of the stack. I added z-index for the bottom navigation container to fix this issue and also increased the modal overlay zIndex in order to go on top of bottom navigation.