### PR TITLE
Fix account deletion flow to use same logout function that is used el…

### DIFF
--- a/src/components/Account/index.js
+++ b/src/components/Account/index.js
@@ -72,7 +72,7 @@ const Account = props => {
   }
 
   return (
-    <div className="account-update-container">
+    <main className="account-update-container">
       <div className="account-header">
         <h1>Muokkaa tietojasi</h1>
         <ButtonContainer
@@ -83,10 +83,7 @@ const Account = props => {
         </ButtonContainer>
       </div>
       <div className="account-info-text">
-        <h3>
-          Täällä voit muokata rekisteröitymistietojasi. Nämä tiedot näkyvät vain
-          sinulle. Kaikki tiedot ovat pakollisia.
-        </h3>
+        <p>Nämä tiedot näkyvät vain sinulle. Kaikki tiedot ovat pakollisia.</p>
       </div>
       <div className="account-box-outer">
         <div className="account-box-inner">
@@ -94,6 +91,7 @@ const Account = props => {
           <ButtonContainer
             className="account-edit-button"
             onClick={() => openModal('firstname')}
+            label="Muokkaa etunimeä"
           >
             Muokkaa
           </ButtonContainer>
@@ -106,6 +104,7 @@ const Account = props => {
           <ButtonContainer
             className="account-edit-button"
             onClick={() => openModal('lastname')}
+            label="Muokkaa sukunimeä"
           >
             Muokkaa
           </ButtonContainer>
@@ -118,6 +117,7 @@ const Account = props => {
           <ButtonContainer
             className="account-edit-button"
             onClick={() => openModal('email')}
+            label="Muokkaa sähköpostia"
           >
             Muokkaa
           </ButtonContainer>
@@ -130,6 +130,7 @@ const Account = props => {
           <ButtonContainer
             className="account-edit-button"
             onClick={() => openModal('phoneNumber')}
+            label="Muokkaa puhelinnumeroa"
           >
             Muokkaa
           </ButtonContainer>
@@ -142,6 +143,7 @@ const Account = props => {
           <ButtonContainer
             className="account-edit-button"
             onClick={() => openModal('password')}
+            label="Muokkaa salasanaa"
           >
             Muokkaa
           </ButtonContainer>
@@ -181,7 +183,7 @@ const Account = props => {
         deleteUser={handleDeleteUser}
         deleteError={deleteError}
       />
-    </div>
+    </main>
   )
 }
 

--- a/src/components/Account/index.js
+++ b/src/components/Account/index.js
@@ -7,7 +7,14 @@ import * as API from '../../api/user/user'
 import './styles.scss'
 
 const Account = props => {
-  const { nodeUser, mmuser, updateUser, updatePassword, history } = props
+  const {
+    nodeUser,
+    mmuser,
+    updateUser,
+    updatePassword,
+    history,
+    userLogout,
+  } = props
   const [showModal, setShowModal] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [deleteError, setDeleteError] = useState(null)
@@ -33,9 +40,7 @@ const Account = props => {
       const token = localStorage.getItem('authToken')
       const res = await API.deleteUser(data, id, token)
       if (res && res.success) {
-        localStorage.removeItem('userId')
-        localStorage.removeItem('authToken')
-        history.push('/')
+        userLogout()
       } else if (res && res.message) {
         setDeleteError(res.message)
       }
@@ -193,6 +198,7 @@ Account.propTypes = {
   updateUser: propTypes.func.isRequired,
   updatePassword: propTypes.func.isRequired,
   history: propTypes.instanceOf(Object).isRequired,
+  userLogout: propTypes.func.isRequired,
 }
 
 export default memo(Account)

--- a/src/components/Account/styles.scss
+++ b/src/components/Account/styles.scss
@@ -1,5 +1,9 @@
 @import '../../styles/colors.scss';
 
+.account-info-text {
+  font-size: 1.17em;
+}
+
 .account-update-container {
   margin: 30px 35px;
   display: flex;
@@ -60,7 +64,7 @@
 }
 
 .account-delete-button {
-  color: red;
+  color: black;
   min-width: 230px;
   align-self: center;
   height: 42px;
@@ -87,7 +91,7 @@
 }
 
 .delete-text {
-  color: red;
+  color: black;
 }
 
 .delete-box {

--- a/src/containers/ChangeAccountInfoContainer.js
+++ b/src/containers/ChangeAccountInfoContainer.js
@@ -2,14 +2,26 @@ import React, { memo } from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import PropTypes from 'prop-types'
+import { logout } from 'mattermost-redux/actions/users'
 import Account from '../components/Account'
 import {
   updateUser as updateUserAction,
   updateUserPassword as updateUserPasswordAction,
 } from '../store/user/userAction'
+import logoutHandler from '../utils/userLogout'
+import * as API from '../api/user/user'
 
 const ChangeAccountInfoContainer = props => {
-  const { myUserInfo, currentUser, updateUser, updatePassword, history } = props
+  const {
+    myUserInfo,
+    currentUser,
+    updateUser,
+    updatePassword,
+    history,
+    logout: matterMostLogout,
+  } = props
+
+  const handleLogout = () => logoutHandler(API.userLogout, matterMostLogout)
 
   return (
     <Account
@@ -18,6 +30,7 @@ const ChangeAccountInfoContainer = props => {
       updateUser={updateUser}
       updatePassword={updatePassword}
       history={history}
+      userLogout={handleLogout}
     />
   )
 }
@@ -41,6 +54,7 @@ const mapDispatchToProps = dispatch =>
     {
       updateUser: updateUserAction,
       updatePassword: updateUserPasswordAction,
+      logout,
     },
     dispatch
   )
@@ -60,6 +74,7 @@ ChangeAccountInfoContainer.propTypes = {
   updateUser: PropTypes.func.isRequired,
   updatePassword: PropTypes.func.isRequired,
   history: PropTypes.instanceOf(Object).isRequired,
+  logout: PropTypes.func.isRequired,
 }
 
 export default connect(


### PR DESCRIPTION
Changed both initial delete user and handleDeleteUserNow functions to utilise the same logout function that is used elsewhere. Also changed the handleDeleteUserNow order a little bit. I think now this should work, since both node user and mattermost user are actually logged out when deleting the user (either first time or permanently).